### PR TITLE
fix: let admins write and archive at the same time

### DIFF
--- a/app/Filament/Resources/ExamAppealResource.php
+++ b/app/Filament/Resources/ExamAppealResource.php
@@ -153,10 +153,11 @@ class ExamAppealResource extends Resource
                             }),
 
                         RichEditor::make('final_judgment_reason')
+                            ->label('Observações da coordenação')
                             ->columnSpan(2)
                             ->helperText('Campo para anotações sobre parecer.')
                             ->disabled(fn(Get $get): bool => $get('archived') === true)
-                            ->label('Observações da coordenação'),
+                            ->dehydrated(),
 
                         Checkbox::make('archived')
                             ->columnSpanFull()

--- a/app/Filament/Resources/FoResource.php
+++ b/app/Filament/Resources/FoResource.php
@@ -276,6 +276,7 @@ class FoResource extends Resource
                         RichEditor::make('final_judgment_reason')
                             ->helperText('Campo para anotações sobre parecer do FO, ordem de serviço, etc.')
                             ->disabled(fn(Get $get): bool => $get('paid') === true)
+                            ->dehydrated()
                             ->label('Observações da coordenação'),
 
                         Checkbox::make('paid')

--- a/app/Filament/Resources/LeaveResource.php
+++ b/app/Filament/Resources/LeaveResource.php
@@ -256,7 +256,8 @@ class LeaveResource extends Resource
                         RichEditor::make('final_judgment_reason')
                             ->helperText('Campo para anotações sobre parecer.')
                             ->label('Observações da coordenação')
-                            ->disabled(fn(Get $get): bool => $get('paid') === true),
+                            ->disabled(fn(Get $get): bool => $get('paid') === true)
+                            ->dehydrated(),
 
                         Checkbox::make('paid')
                             ->helperText('O aluno gozou a dispensa e anexou documento comprobatório.')

--- a/app/Filament/Resources/MakeUpExamResource.php
+++ b/app/Filament/Resources/MakeUpExamResource.php
@@ -148,8 +148,10 @@ class MakeUpExamResource extends Resource
                             }),
 
                         RichEditor::make('final_judgment_reason')
+                            ->label('Observações da coordenação')
                             ->helperText('Campo para anotações sobre parecer.')
-                            ->label('Observações da coordenação'),
+                            ->disabled(fn(Get $get): bool => $get('archived') === true)
+                            ->dehydrated(),
 
                         Checkbox::make('archived')
                             ->helperText('Segunda chamada concluída')

--- a/app/Filament/Resources/SwitchShiftResource.php
+++ b/app/Filament/Resources/SwitchShiftResource.php
@@ -227,7 +227,9 @@ class SwitchShiftResource extends Resource
 
                         RichEditor::make('final_judgment_reason')
                             ->helperText('Campo para anotações sobre parecer.')
-                            ->label('Observações da coordenação'),
+                            ->label('Observações da coordenação')
+                            ->disabled(fn(Get $get): bool => $get('paid') === true)
+                            ->dehydrated(),
 
                         Checkbox::make('paid')
                             ->label('Informado às OBMs/Arquivado'),


### PR DESCRIPTION
All resources that had a field where the admin could write had a bug where if the user wrote and archived, the text would be lost. This problem was fixed using dehydrated for the text fields.