### PR TITLE
fix(security): correct cron permissions from 777 to 755

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -33,7 +33,7 @@ RUN addgroup $NON_ROOT_USER wheel
 
 # Set cron job
 COPY ./.deploy/config/crontab /etc/crontabs/$NON_ROOT_USER
-RUN chmod 777 /usr/sbin/crond
+RUN chmod 755 /usr/sbin/crond
 RUN chown -R $NON_ROOT_USER:$NON_ROOT_GROUP /etc/crontabs/$NON_ROOT_USER && setcap cap_setgid=ep /usr/sbin/crond
 
 # Switch to non-root 'app' user & install app dependencies


### PR DESCRIPTION
## 🔒 Security Fix: Cron Permissions

### Problem
The Dockerfile was setting dangerous `777` permissions on `/usr/sbin/crond`, allowing **any user** to modify the cron binary. This is a critical security vulnerability that could allow attackers to replace the cron binary with a malicious version.

### Solution
Changed permissions from `777` to `755`:
- ✅ Owner (root) can read, write, and execute
- ✅ Group can read and execute
- ✅ Others can read and execute
- ❌ **Only root can modify** the binary (prevents tampering)

### Impact
- Cron continues to function normally
- Capabilities (`setcap cap_setgid=ep`) remain unchanged
- Significantly reduces attack surface
- Prevents binary replacement attacks

### Testing
- [x] Cron functionality verified
- [x] Permissions tested with non-root user
- [x] No breaking changes

### Related to
Recent security incident investigation where malicious PHP files were found in production.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)