### PR TITLE
fix(security): block direct PHP file execution

### DIFF
--- a/.deploy/config/Caddyfile
+++ b/.deploy/config/Caddyfile
@@ -1,6 +1,13 @@
 :80 {
     root * /srv/app/public
 
+    # SECURITY: Block direct PHP execution (except index.php)
+    @block_php {
+        path *.php
+        not path /index.php
+    }
+    respond @block_php 404
+
     @websockets {
         header Connection *upgrade*
         header Upgrade    websocket


### PR DESCRIPTION
## 🔒 Security Fix: Block Direct PHP Execution

### Problem
The Caddyfile was configured to execute **ANY** `.php` file directly:
```
https://fenix.cbmgo.org/malicious.php ← Would execute!
https://fenix.cbmgo.org/webshell.php ← Would execute!
```

This allowed the recent security incident where `rsxawz9t.php` was executed directly, bypassing Laravel's security.

### Solution
Added a simple security rule that blocks execution of ANY `.php` file except `index.php`:

```caddy
@block_php {
    path *.php
    not path /index.php
}
respond @block_php 404
```

Now ALL requests must go through Laravel's front controller (`index.php`).

### What This Fixes
- ✅ Blocks direct execution of uploaded PHP files
- ✅ Prevents webshell attacks
- ✅ Forces all traffic through Laravel router
- ✅ Returns 404 for any `.php` except `index.php`

### Impact
- No breaking changes
- Laravel routing works normally
- Static files (CSS, JS, images) unaffected
- Only blocks direct `.php` file access

### Testing
After deploy, verify:
```bash
curl https://fenix.cbmgo.org/test.php  # Should return 404
curl https://fenix.cbmgo.org/          # Should work normally
```