### PR TITLE
revert: remove PHP blocking rule that breaks login

### DIFF
--- a/.deploy/config/Caddyfile
+++ b/.deploy/config/Caddyfile
@@ -1,13 +1,6 @@
 :80 {
     root * /srv/app/public
 
-    # SECURITY: Block direct PHP execution (except index.php)
-    @block_php {
-        path *.php
-        not path /index.php
-    }
-    respond @block_php 404
-
     @websockets {
         header Connection *upgrade*
         header Upgrade    websocket


### PR DESCRIPTION
## 🔧 Hotfix: Revert Caddyfile PHP Blocking

### Problem
The security rule added in #118 is **breaking the application**:
- Users cannot log in
- Livewire requests are blocked
- Returns 404 for legitimate routes

### Root Cause
The rule blocks ANY URL containing `.php`, including:
- Internal Livewire/Filament routes
- Laravel framework routes
- Any route pattern with `.php` in the path

### Solution
Revert the `@block_php` rule to restore functionality.

### Next Steps
After this fix is deployed, we'll implement a **different security approach**:
- Monitor `public/` directory for new PHP files
- Auto-delete suspicious files on container startup
- Add file integrity monitoring

### Priority
🔴 **CRITICAL** - Application is currently broken in production