### PR TITLE
fix(fo): prevent issuer from editing FO after justification

### DIFF
--- a/app/Filament/Resources/FoResource.php
+++ b/app/Filament/Resources/FoResource.php
@@ -180,10 +180,11 @@ class FoResource extends Resource
                     ->disabled(function (string $operation, Get $get): bool {
                         $military = Military::firstWhere('rg', auth()->user()->rg);
 
-                        // Do not allow to edit or delete if the user is not the issuer or the FO is not in progress
+                        // Do not allow to edit or delete if the user is not the issuer, the FO is not in progress, or the student has already justified
                         return $operation !== 'create' &&
                             (!$military || $get('issuer') !== $military->id ||
-                                ($get('status') !== StatusFoEnum::EM_ANDAMENTO->value));
+                                $get('status') !== StatusFoEnum::EM_ANDAMENTO->value ||
+                                !empty($get('excuse')));
                     })
                     ->schema([
                         Select::make('type')


### PR DESCRIPTION
## Summary
- Impede o observador (issuer) de editar o FO após o aluno preencher a justificativa (`excuse`)
- A seção "Emitir FO" fica desabilitada quando o campo de justificativa já foi preenchido

## Test plan
- [ ] Criar um FO como observador e verificar que é editável
- [ ] Justificar o FO como aluno
- [ ] Tentar editar o FO como observador e verificar que a seção está desabilitada

🤖 Generated with [Claude Code](https://claude.com/claude-code)